### PR TITLE
CI - Replace scenario `ember-lts-3.24` with `ember-lts-3.16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
       fail-fast: true
       matrix:
         try-scenario:
+          - ember-lts-3.16
           - ember-lts-3.20
-          - ember-lts-3.24
           - ember-release
           - ember-classic
           - ember-default-with-jquery

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,18 +9,18 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
+        name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
-            'ember-source': '~3.20.5',
+            'ember-source': '~3.16.0',
           },
         },
       },
       {
-        name: 'ember-lts-3.24',
+        name: 'ember-lts-3.20',
         npm: {
           devDependencies: {
-            'ember-source': '~3.24.3',
+            'ember-source': '~3.20.5',
           },
         },
       },


### PR DESCRIPTION
## CI

### Replace test scenario `ember-lts-3.24` with `ember-lts-3.16` (#147)

At the time of writing these changes, the add-on already runs with `ember-cli@3.24` so testing the LTS v3.24 in the CI does not make sense.