### PR TITLE
Release v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-embedded",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Control how your Ember applications boot in non-Ember pages/apps.",
   "homepage": "https://github.com/peopledoc/ember-cli-embedded",
   "keywords": [


### PR DESCRIPTION
## Build

### Bump `eslint-plugin-ember` from 10.5.5 to 10.5.7 (#150)

### Bump `@types/ember__object` from 3.12.5 to 3.12.6 (#151)


## CI

### Replace test scenario `ember-lts-3.24` with `ember-lts-3.16` (#148)

At the time of writing these changes, the add-on already runs with `ember-cli@3.24` so testing the LTS v3.24 in the CI does not make sense.

Follow the native implementation of Ember.js:
- https://github.com/ember-cli/ember-addon-output/blob/v3.24.0/config/ember-try.js
- https://github.com/ember-cli/ember-addon-output/blob/v3.24.0/.travis.yml#L49-L56


## Documentation

### Lower compatible version of Ember.js (#148)

Because the CI will test against Ember.js v3.16, we should mention the add-on is compatible with this version.

### Add a section about TypeScript support (#149)


## Features

### Allow to pass type of embedded options to Service `embedded` (#149)

The Service `embedded` now accepts a generic type parameter to improve the accuracy of what it can return.

```ts
import Component from '@glimmer/component';
import { inject as service } from '@ember/service';

import type EmbeddedService from 'ember-cli-embedded/services/embedded';

export default class MyComponent extends Component {
  @service
  declare embedded: EmbeddedService<{ one: string, two?: string }>;

  get one() { // Return type inferred: `string | undefined`
    return this.embedded.get('one');
  }

  get two() {
    // TypeScript returns an error as `twoo` is not a recognised key
    return this.embedded.get('twoo');
  }
}
```


## Fixes

### Fix required versions of Node.js (#148)

Node.js v10 is actually not supported so we should not mention it in our `package.json`.


## Refactor

### Update Service `embedded` to native JS class (#149)

### Make tests of Service `embedded` stricter (#149)

Prefer `assert.strictEqual()` over `assert.equal()`.