### PR TITLE
CI - Run all `ember-try` scenarios despite failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,17 @@ name: CI
 on:
   push:
     branches:
-      - main
       - master
   pull_request: {}
 
 env:
-  NODE_VERSION: '12'
+  NODE_VERSION: 12
 
 jobs:
-  lint:
-    name: Lint
+  test:
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     steps:
       - uses: actions/checkout@v2
 
@@ -31,33 +29,14 @@ jobs:
       - name: Lint
         run: yarn run lint
 
-  test:
-    name: Tests
-    needs: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: yarn
-
-      - name: Install Dependencies
-        run: yarn install --frozen-lockfile
-
       - name: Run Tests
         run: yarn run test:ember
 
   floating:
     name: Floating Dependencies
-    needs: lint
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     steps:
       - uses: actions/checkout@v2
 
@@ -77,7 +56,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## CI

#### Run all `ember-try` scenarios despite failure (#156)
    
See https://github.com/ember-cli/ember-cli/pull/9661 :

> The existing configs use `fail-fast` or `fast_finish` to abort builds once one scenario has failed. However, because addon projects will often support multiple versions of Ember as well as use forward-looking testing for beta/canary versions to catch issues, we want to ensure that all scenarios get run even if one of them fail. This is especially important for the GitHub Actions workflow, which doesn't have a concept of "allowed failures". As such, it's quite common that a build such as ember-canary might fail but still be ok to merge, if all other scenarios pass. By setting this config to true, we could hit scenarios where an expected failure occurred and all other builds were automatically aborted, thus preventing maintainers from knowing if the other scenarios would pass.

#### Merge jobs `lint` and `tests` (#156)

These 2 sequential jobs were 95 % similar, the only difference being the last step: the lint and the test suite. This a waste of resources as they will instantiate a new runner.

Instead we run them in the same job/same runner, and because GitHub Actions steps are sequential too, the step for the tests suite will only run if the lint step is successful.
