### PR TITLE
ci: fix URL to compare new and old tags

### DIFF
--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ncipollo/release-action@v1
         env:
           REPO_URL: '${{ github.server_url }}/${{ github.repository }}'
-          TAGS_DIFF: 'v${{ needs.create-git-tag.outputs.new-version }}...v${{ needs.create-git-tag.outputs.old-version }}'
+          TAGS_DIFF: 'v${{ needs.create-git-tag.outputs.old-version }}...v${{ needs.create-git-tag.outputs.new-version }}'
         with:
           body: '${{ env.REPO_URL }}/compare/${{ env.TAGS_DIFF }}'
           name: Release ${{ needs.create-git-tag.outputs.new-tag }}


### PR DESCRIPTION
## CI

#### Fix URL to compare new and old tags (#160)

The URL generated is incorrect `new_tag...old_tag`:
https://github.com/peopledoc/ember-cli-embedded/compare/v2.3.0...v2.2.0

The correct URL should be `old_tag...new_tag`:
https://github.com/peopledoc/ember-cli-embedded/compare/v2.2.0...v2.3.0