### PR TITLE
ci: fix concurrency group's name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   NODE_VERSION: 12
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## CI

#### Fix empty concurrency group's name (#165)

Previously the concurrency group's name was empty when running on `master` ([see the faulty run](https://github.com/peopledoc/ember-cli-embedded/actions/runs/1398906462)) because the context `${{ github.head_ref }}` [is only available in PR-related events](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).

The group's name is now prefixed with `ci-` to ensure it will never be empty.
