### PR TITLE
breaking: drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   org:
     uses: DazzlingFugu/.github/.github/workflows/js--emberjs-addons.yml@master
     with:
-      node-version: 12
+      node-version: 14
       package-manager: yarn
       ember-try-scenarios: "[
           'ember-lts-3.20',

--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: DazzlingFugu/.github/.github/workflows/js--tag-release-publish.yml@master
     with:
-      node-version: 12
+      node-version: 14
       package-manager: yarn
     secrets:
       npm-automation-token: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We found it especially useful, for example, when migrating an existing app to Em
 
 * Ember.js v3.20 or above
 * Ember CLI v3.20 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack": "^5.74.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ember-template-lint": "^4.8.0",
     "ember-try": "^2.0.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-ember": "^10.6.1",
+    "eslint-plugin-ember": "^11.0.6",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-qunit": "^7.3.1",
     "loader.js": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5551,10 +5551,10 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-ember@^10.6.1:
-  version "10.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-10.6.1.tgz#04ea84cc82307f64a2faa4f2855b30e5ebf9f722"
-  integrity sha512-R+TN3jwhYQ2ytZCA1VkfJDZSGgHFOHjsHU1DrBlRXYRepThe56PpuGxywAyDvQ7inhoAz3e6G6M60PzpvjzmNg==
+eslint-plugin-ember@^11.0.6:
+  version "11.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-11.0.6.tgz#95fc44639b9f8f3d5a0f7a20bd06903a32194798"
+  integrity sha512-iQzqn8/GdBbNv2T3YetpjEBemoH0v9e9ea8Bu6JLOX2TN+HMK2l52/QBRFgrnaxLXBjPO3iy2c3sCieYV27EvQ==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
     css-tree "^2.0.4"


### PR DESCRIPTION
## Breaking

### Drop node 12 support (#228)

## Build

### Upgrade [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) to v11 (#228)