### PR TITLE
BREAKING Build/ Drop support for Ember 3.20 and 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       node-version: 14
       package-manager: yarn
       ember-try-scenarios: "[
-          'ember-lts-3.20',
-          'ember-lts-3.24',
           'ember-lts-3.28',
           'ember-release',
           'ember-beta',

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ We found it especially useful, for example, when migrating an existing app to Em
 ## Compatibility
 
 
-* Ember.js v3.20 or above
-* Ember CLI v3.20 or above
+* Ember.js v3.28 or above
+* Ember CLI v3.28 or above
 * Node.js v14 or above
 
 ## Usage

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -26,6 +26,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-beta',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
@@ -34,6 +35,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,22 +9,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Breaking
### Drop support for Ember 3.20 and 3.24 (#257)
These versions are not compatible with `ember-qunit` version.

## CI
### Allow beta and canary to fail (#257)
For now, we have a bug with the `fs-extra` dependency of `ember-try`. We'll investigate after fixing the CI to unblock dependencies updates.

