### PR TITLE
release: 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-embedded",
   "description": "Control how your Ember applications boots in non-Ember pages/apps.",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": {
     "name": "Dazzling Fugu",


### PR DESCRIPTION
# Breaking

**BREAKING Build/ Drop support for Ember 3.20 and 3.24 #257**
**breaking: drop node 12 support #228**

# Build

### Update Ember to 4.8 (#246)
- Bumps Ember from 4.4 to 4.8 using `ember-cli-update`
- Bumps a couple of dependencies: `@ember/test-helpers`, `@types/ember__test-helpers`, `ember-auto-import`, `ember-qunit`, `webpack`

### Move `ember-export-application-global` to deps (#246)
Related to / closes #199 
- Move [`ember-export-application-global`](https://github.com/ember-cli/ember-export-application-global) in dependencies as it's no longer installed by the `app` blueprint.
- Add a ⚠️ about [`ember-export-application-global`](https://github.com/ember-cli/ember-export-application-global) in the README and fix a few typos > **Note**

### Update `typescript` to 4.9.4 (#245)
### Update `ember-cli-typescript` to 4.9.4 (#245)
### Remove `@types/htmlbars-inline-precompile` (#245)
### Rebuild `yarn.lock` (#245)
### Upgrade [ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript) to v5.1.0 (#195)

# Chore

### Run [ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript) blueprint (#195)

To be up to date with [ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript) config and recommandations in `tsconfig.json`

Running blueprints also add back `@types/ember*` packages in devDependencies, which solves a side effect introduced by https://github.com/peopledoc/ember-cli-embedded/pull/157/. 
- If we remove some `@types/ember*` packages from our devDependencies, they will still be included by other packages but they will resolve to a version sometimes incompatible with other `@types/ember__*` packages, resulting of type errors in build
- Keeping us sync with [ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript) ensure we don't face this issue again in this future

Example of build failing when we remove some `@types/ember__x` packages that we don't use (like routing, engine, array... ; even after a `yarn-deduplicate && yarn`):
![Capture d’écran 2022-06-27 à 23 31 56](https://user-images.githubusercontent.com/56396753/176041406-7586a375-5c45-4657-b1c2-d71cbedd2fb0.png)

### Run yarn-deduplicate && yarn (#195)

Fix build and test by resolving `@types/ember*` packages to one single version in the `yarn.lock` (otherwise we would have sometimes two different versions for some `@types/ember*` packages, which would leads to type conflicts when building app

# Updates deps

build(deps-dev): bump ember-template-lint from 5.7.2 to 5.7.3 #259
build(deps-dev): bump ember-template-lint from 4.18.2 to 5.7.2 #258
build(deps-dev): bump webpack from 5.75.0 to 5.76.0 #255
build(deps): bump minimist from 0.2.2 to 0.2.4 #254
build(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 #251
build(deps-dev): bump typescript from 4.7.4 to 4.9.4 #245
build(deps): bump express from 4.17.1 to 4.18.2 #243
build(deps): bump decode-uri-component from 0.2.0 to 0.2.2 #241
build(deps): bump loader-utils from 1.4.1 to 1.4.2 #236
build(deps): bump loader-utils from 1.4.0 to 1.4.1 #233
build(deps-dev): bump ember-qunit from 5.1.5 to 6.0.0 #232
build(deps-dev): bump @types/ember__controller from 4.0.0 to 4.0.1 #229
build(deps): bump mout from 1.2.3 to 1.2.4 #226
build(deps): bump ember-cli-typescript from 5.1.0 to 5.1.1 #224
build(deps-dev): bump @types/ember__component from 4.0.8 to 4.0.10 #222
build(deps-dev): bump @types/ember-qunit from 5.0.0 to 5.0.1 #218
build(deps-dev): bump @types/ember from 4.0.0 to 4.0.1 #217
build(deps-dev): bump @types/ember__application from 4.0.0 to 4.0.1 #214
build(deps-dev): bump @types/ember__routing from 4.0.7 to 4.0.10 #213
build(deps): bump ember-cli-babel from 7.26.6 to 7.26.11 #210
Build/ update ember-auto-import & webpack, clean dependencies #205
build(deps): bump terser from 4.8.0 to 4.8.1 #201
build(deps-dev): bump eslint-plugin-qunit from 6.2.0 to 7.3.1 #200
build: upgrade ember to v4.4 #196
build: upgrade ember-cli-typescript to v5.1.0 #195
Auto-update list of contributors #193
