### PR TITLE
breaking: drops Node v14 & upgrades to Node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   org:
     uses: DazzlingFugu/.github/.github/workflows/js--emberjs-addons.yml@master
     with:
-      node-version: 14
+      node-version: 16
       package-manager: yarn
       ember-try-scenarios: "[
           'ember-lts-3.28',

--- a/.github/workflows/tag-release-publish.yml
+++ b/.github/workflows/tag-release-publish.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: DazzlingFugu/.github/.github/workflows/js--tag-release-publish.yml@master
     with:
-      node-version: 14
+      node-version: 16
       package-manager: yarn
     secrets:
       npm-automation-token: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We found it especially useful, for example, when migrating an existing app to Em
 
 * Ember.js v3.28 or above
 * Ember CLI v3.28 or above
-* Node.js v14 or above
+* Node.js v16 or above
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-ember": "^11.1.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-qunit": "^7.3.1",
+    "eslint-plugin-qunit": "^8.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit": "^2.19.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@ember/string": "^3.1.1"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4490,10 +4490,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-qunit@^7.3.1:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-qunit/-/eslint-plugin-qunit-7.3.4.tgz#2465b6f29ff56fbe9b741bde2740dec109ee9bec"
-  integrity sha512-EbDM0zJerH9zVdUswMJpcFF7wrrpvsGuYfNexUpa5hZkkdFhaFcX+yD+RSK4Nrauw4psMGlcqeWUMhaVo+Manw==
+eslint-plugin-qunit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-qunit/-/eslint-plugin-qunit-8.0.0.tgz#92df9b8cc144a67edaf961e9c4db75d98065ce85"
+  integrity sha512-ly2x/pmJPcS0ztGAPap6qLC13GjOFwhBbvun0K1dAjaxaC6KB3TYjeBo+5pGvXqL3WdicmYxEKhTGwmhvoxMBQ==
   dependencies:
     eslint-utils "^3.0.0"
     requireindex "^1.2.0"


### PR DESCRIPTION
## Breaking
### Drops support for `Node v14` (#286)

## Chore
### Updates to `Node v16` (#286)
### Updates to `eslint-plugin-qunit v8` (which requires Node >=16) (#286)