### PR TITLE
Release v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-embedded",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Control how your Ember application boots in non-Ember pages/apps.",
   "keywords": [
     "ember",


### PR DESCRIPTION
## Breaking changes

### Upgrade add-on to Ember.js v5.4.0 (#305)

- Ember.js v4.8 or above is now required
- Ember CLI v4.8 or above is now required
- Node.js v18 or above is now required

## Chore

### Fully migrate add-on to TypeScript (#305)

- The add-on is now 100% TypeScript-based as it was regenerated with the latest specification and the `--typescript` flag.
  - https://github.com/ember-cli/ember-cli/releases/tag/v4.9.0
  - https://github.com/ember-cli/ember-cli/pull/9972

  which also means it does not rely on `ember-cli-typescript` anymore:
  - https://github.com/ember-cli/ember-cli/pull/10283

## Build

- Bump `typescript` from 4.9.4 to 5.1.6 (#284)
- Bump `webpack` from 5.86.0 to 5.88.2 (#287)
- Bump `ember-resolver` from 9.0.1 to 11.0.1 (#289)
- Bump `@ember/test-helpers` from 2.9.3 to 2.9.4 (#290)
- Bump `@types/ember__debug` from 4.0.3 to 4.0.4 (#291)
- Bump `eslint-plugin-ember` from 11.5.2 to 11.11.1 (#294)
- Bump `ember-cli-htmlbars` from 6.2.0 to 6.3.0 (#295)
- Bump `@types/ember__controller` from 4.0.4 to 4.0.8 (#296)
- Bump `postcss` from 8.4.19 to 8.4.31 (#297)
- Bump `@types/ember__debug` from 4.0.4 to 4.0.5 (#298)
- Bump `@types/ember` from 4.0.4 to 4.0.6 (#299)
- Bump `@babel/traverse` from 7.21.4 to 7.23.2 (#300)
- Bump `@embroider/test-setup` from 1.8.3 to 3.0.2 (#301)
- Bump `@types/ember__engine` from 4.0.4 to 4.0.8 (#302)
- Bump `@types/ember__destroyable` from 4.0.1 to 4.0.3 (#303)
- Bump `ember-template-lint` from 5.7.3 to 5.11.2 (#304)