### PR TITLE
build: update `ember-cli` to v5.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.2.2",
     "ember-auto-import": "^2.6.3",
-    "ember-cli": "~5.4.0",
+    "ember-cli": "~5.4.2",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-qunit": "^8.0.1",
     "ember-resolver": "^11.0.1",
-    "ember-source": "~5.4.0",
+    "ember-source": "~5.8.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^3.0.0",
     "eslint": "^8.52.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,7 @@
     "@babel/highlight" "^7.24.2"
     picocolors "^1.0.0"
 
-"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.22.9", "@babel/compat-data@^7.23.2":
-  version "7.23.2"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.2.tgz#6a12ced93455827037bfb5ed8492820d60fc32cc"
-  integrity sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==
-
-"@babel/compat-data@^7.23.5":
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.22.9", "@babel/compat-data@^7.23.2", "@babel/compat-data@^7.23.5":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.24.1.tgz#31c1f66435f2a9c329bb5716a6d6186c516c3742"
   integrity sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==
@@ -98,22 +93,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.22.11", "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.22.5", "@babel/helper-create-class-features-plugin@^7.5.5":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz#97a61b385e57fe458496fad19f8e63b63c867de4"
-  integrity sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-environment-visitor" "^7.22.5"
-    "@babel/helper-function-name" "^7.22.5"
-    "@babel/helper-member-expression-to-functions" "^7.22.15"
-    "@babel/helper-optimise-call-expression" "^7.22.5"
-    "@babel/helper-replace-supers" "^7.22.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    semver "^6.3.1"
-
-"@babel/helper-create-class-features-plugin@^7.24.4":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.22.11", "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.22.5", "@babel/helper-create-class-features-plugin@^7.24.4", "@babel/helper-create-class-features-plugin@^7.5.5":
   version "7.24.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz#c806f73788a6800a5cfbbc04d2df7ee4d927cce3"
   integrity sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==
@@ -200,12 +180,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
-  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
-
-"@babel/helper-plugin-utils@^7.24.0":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.24.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz#945681931a52f15ce879fd5b86ce2dae6d3d7f2a"
   integrity sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==
@@ -219,16 +194,7 @@
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-wrap-function" "^7.22.20"
 
-"@babel/helper-replace-supers@^7.22.20", "@babel/helper-replace-supers@^7.22.5", "@babel/helper-replace-supers@^7.22.9":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz#e37d367123ca98fe455a9887734ed2e16eb7a793"
-  integrity sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-member-expression-to-functions" "^7.22.15"
-    "@babel/helper-optimise-call-expression" "^7.22.5"
-
-"@babel/helper-replace-supers@^7.24.1":
+"@babel/helper-replace-supers@^7.22.20", "@babel/helper-replace-supers@^7.22.5", "@babel/helper-replace-supers@^7.22.9", "@babel/helper-replace-supers@^7.24.1":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz#7085bd19d4a0b7ed8f405c1ed73ccb70f323abc1"
   integrity sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==
@@ -268,12 +234,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
-"@babel/helper-validator-option@^7.22.15":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz#694c30dfa1d09a6534cdfcafbe56789d36aba040"
-  integrity sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==
-
-"@babel/helper-validator-option@^7.23.5":
+"@babel/helper-validator-option@^7.22.15", "@babel/helper-validator-option@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz#907a3fbd4523426285365d1206c423c4c5520307"
   integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
@@ -1726,16 +1687,7 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
-  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/gen-mapping@^0.3.5":
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
   integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
@@ -1749,12 +1701,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
-"@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
-
-"@jridgewell/set-array@^1.2.1":
+"@jridgewell/set-array@^1.0.1", "@jridgewell/set-array@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
@@ -1772,18 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.20"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz#72e45707cf240fa6b081d0366f8265b0cd10197f"
-  integrity sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -2870,15 +2809,7 @@ babel-plugin-ember-modules-api-polyfill@^3.5.0:
   dependencies:
     ember-rfc176-data "^0.3.17"
 
-babel-plugin-ember-template-compilation@^2.0.0, babel-plugin-ember-template-compilation@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.1.tgz#81ad03f572e94bda92ebc2c0005d5179e3f7c980"
-  integrity sha512-alinprIQcLficqkuIyeKKfD4HQOpMOiHK6pt6Skj/yjoPoQYBuwAJ2BoPAlRe9k/URPeVkpMefbN3m6jEp7RsA==
-  dependencies:
-    "@glimmer/syntax" "^0.84.3"
-    babel-import-util "^2.0.0"
-
-babel-plugin-ember-template-compilation@^2.1.1:
+babel-plugin-ember-template-compilation@^2.0.0, babel-plugin-ember-template-compilation@^2.0.1, babel-plugin-ember-template-compilation@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.2.tgz#e3fdff0458730675716e320d2c4e0aa8fe8c4b25"
   integrity sha512-wdT2F9/n6uC1rLvAjXCx5+fXbwkl8MIcwt0rg5csWedPbERdzQqhRlDqj0kIwNfUJ9gaXAcKrgSOUXbJcByGOQ==
@@ -9411,20 +9342,10 @@ terser-webpack-plugin@^5.3.10:
     serialize-javascript "^6.0.1"
     terser "^5.26.0"
 
-terser@^5.26.0:
+terser@^5.26.0, terser@^5.7.0:
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.30.0.tgz#64cb2af71e16ea3d32153f84d990f9be0cdc22bf"
   integrity sha512-Y/SblUl5kEyEFzhMAQdsxVHh+utAxd4IuRNJzKywY/4uzSogh3G219jqbDDxYu4MXO9CzY3tSEqmZvW6AoEDJw==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.8.2"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@^5.7.0:
-  version "5.24.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.24.0.tgz#4ae50302977bca4831ccc7b4fef63a3c04228364"
-  integrity sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,10 +4576,10 @@ ember-cli-version-checker@^5.1.1, ember-cli-version-checker@^5.1.2:
     semver "^7.3.4"
     silent-error "^1.1.1"
 
-ember-cli@~5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-5.4.0.tgz#180cb5b83a1ed65f43d43ec592dcea2634e3df85"
-  integrity sha512-00RfyeDGTo9OtsmxbIqJIKM0wZvvOGAn1w4A9hFrENcuE7I3HKCb3QYKLHLXywG91fTsWbmXRfCL1kQ5pOva4A==
+ember-cli@~5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-5.4.2.tgz#d91c42ad6a974ba75d6ca87db9087b7c9730ffd3"
+  integrity sha512-EeeiTHo+rtat+YRv01q64Wmo+MRZETcZ7bPKBU14h9gSqSU0bHj57KGKsaQ+av8sOUojwWSqp+GQfOtwuWDgYA==
   dependencies:
     "@pnpm/find-workspace-dir" "^6.0.2"
     broccoli "^3.5.2"
@@ -4634,7 +4634,7 @@ ember-cli@~5.4.0:
     is-git-url "^1.0.0"
     is-language-code "^3.1.0"
     isbinaryfile "^5.0.0"
-    lodash.template "^4.5.0"
+    lodash "^4.17.21"
     markdown-it "^13.0.1"
     markdown-it-terminal "^0.4.0"
     minimatch "^7.4.3"
@@ -7079,11 +7079,6 @@ lodash._isiterateecall@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
   integrity sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==
-
 lodash.assignin@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -7158,21 +7153,6 @@ lodash.omit@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
-
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
 
 lodash.uniq@^4.2.0:
   version "4.5.0"
@@ -9153,16 +9133,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9242,7 +9213,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9262,13 +9233,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -10073,7 +10037,7 @@ workerpool@^6.0.2, workerpool@^6.1.5, workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10086,15 +10050,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,7 +543,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-block-scoping@^7.22.5", "@babel/plugin-transform-block-scoping@^7.23.0":
+"@babel/plugin-transform-block-scoping@^7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.0.tgz#8744d02c6c264d82e1a4bc5d2d501fd8aff6f022"
   integrity sha512-cOsrbmIOXmf+5YbL99/S49Y3j46k/T16b9ml8bm9lP6N9US5iQ2yBK7gpui1pg0V/WMcXdkfKbTb7HXq9u+v4g==
@@ -1238,16 +1238,16 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@glimmer/compiler@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.84.3.tgz#4bcb414c726977f7d290ff56345ea13ac47bf5dd"
-  integrity sha512-cj9sGlnvExP9httxY6ZMivJRGulyaZ31DddCYB5h6LxupR4Nk2d1nAJCWPLsvuQJ8qR+eYw0y9aiY/VeT0krpQ==
+"@glimmer/compiler@0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.87.1.tgz#2a5e5553b0cc853c14848c94111b7f115a2bb1da"
+  integrity sha512-7qXrOv55cH/YW+Vs4dFkNJsNXAW/jP+7kZLhKcH8wCduPfBCQxb9HNh1lBESuFej2rCks6h9I1qXeZHkc/oWxQ==
   dependencies:
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/syntax" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/wire-format" "0.84.3"
-    "@simple-dom/interface" "^1.4.0"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/syntax" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
+    "@glimmer/wire-format" "^0.87.1"
 
 "@glimmer/component@^1.1.0", "@glimmer/component@^1.1.2":
   version "1.1.2"
@@ -1269,6 +1269,15 @@
     ember-cli-version-checker "^3.1.3"
     ember-compatibility-helpers "^1.1.2"
 
+"@glimmer/debug@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/debug/-/debug-0.87.1.tgz#aeb06e3c47d739991f81b9e0742ed855d093fd3e"
+  integrity sha512-rja9/Hofv1NEjIqp8P2eQuHY3+orlS3BL4fbFyvrE+Pw4lRwQPLm6UdgCMHZGGe9yweZAGvNVH6CimDBq7biwA==
+  dependencies:
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
+
 "@glimmer/debug@^0.92.0":
   version "0.92.0"
   resolved "https://registry.yarnpkg.com/@glimmer/debug/-/debug-0.92.0.tgz#3a7cc67cbf8ad5122d722dc2f121b9bfa2c3dbce"
@@ -1278,15 +1287,15 @@
     "@glimmer/util" "^0.92.0"
     "@glimmer/vm" "^0.92.0"
 
-"@glimmer/destroyable@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/destroyable/-/destroyable-0.84.3.tgz#a837ef59bfd64a7b991c76747586205a4a363e41"
-  integrity sha512-4tUw5UR4ntuySPvbcWyCMRjqxMJMV1GewjU3zGq22XvuBVFfq2K9WmuYV9H9FHg8X0MgDwcus+LjxrVSel39Sw==
+"@glimmer/destroyable@0.87.1", "@glimmer/destroyable@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/destroyable/-/destroyable-0.87.1.tgz#e6a5e416b8157b923fa468f6aede8e44854b59f8"
+  integrity sha512-v9kdMq/FCSMcXK4gIKxPCSEcYXjDAnapKVY2o9fCgqky+mbpd0XuGoxaXa35nFwDk69L/9/8B3vXQOpa6ThikA==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/global-context" "0.84.3"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/util" "0.84.3"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
 
 "@glimmer/destroyable@^0.92.0":
   version "0.92.0"
@@ -1303,14 +1312,13 @@
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
   integrity sha512-moRwafNDwHTnTHzyyZC9D+mUSvYrs1Ak0tRPjjmCghdoHHIvMshVbEnwKb/1WmW5CUlKc2eL9rlAV32n3GiItg==
 
-"@glimmer/encoder@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.84.3.tgz#3c7291243e6cd595bf22fc2771286d570dc24d47"
-  integrity sha512-T99YQDhNC/1rOFgiz8k4uzgzQsQ+r1my+WVXRv26o0r+/yOnKYndrb6WH/E9d+XtBIZbm1yCSm2BMFYelR0Nrg==
+"@glimmer/encoder@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.87.1.tgz#1fbd9c1dcbc6b1451502263d582f1eb7e422ad5f"
+  integrity sha512-5oZEkdtYcAbkiWuXFQ8ofSEGH5uzqi86WK9/IXb7Qn4t6o7ixadWk8nhtORRpVS1u4FpAjhsAysnzRFoNqJwbQ==
   dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/vm" "0.84.3"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
 
 "@glimmer/encoder@^0.92.0":
   version "0.92.0"
@@ -1325,12 +1333,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==
 
-"@glimmer/global-context@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.84.3.tgz#f8bf2cda9562716f2ddf3f96837e7559600635c4"
-  integrity sha512-8Oy9Wg5IZxMEeAnVmzD2NkObf89BeHoFSzJgJROE/deutd3rxg83mvlOez4zBBGYwnTb+VGU2LYRpet92egJjA==
-  dependencies:
-    "@glimmer/env" "^0.1.7"
+"@glimmer/global-context@0.87.1", "@glimmer/global-context@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.87.1.tgz#e0da196bc80d2e4852639da8a02b1a51c275db96"
+  integrity sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==
 
 "@glimmer/global-context@^0.92.0":
   version "0.92.0"
@@ -1341,6 +1347,13 @@
   version "0.84.3"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.84.3.tgz#629777a4abe373b0785656f6c8d08989f5784805"
   integrity sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/interfaces@0.87.1", "@glimmer/interfaces@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.87.1.tgz#2b8092db4df791d297473e9ffae97725d08d6efe"
+  integrity sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -1358,23 +1371,20 @@
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/low-level@0.78.2":
-  version "0.78.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.78.2.tgz#bca5f666760ce98345e87c5b3e37096e772cb2de"
-  integrity sha512-0S6TWOOd0fzLLysw1pWZN0TgasaHmYs1Sjz9Til1mTByIXU1S+1rhdyr2veSQPO/aRjPuEQyKXZQHvx23Zax6w==
-
-"@glimmer/manager@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/manager/-/manager-0.84.3.tgz#5be61728713e6c893836540353989462492ca9fe"
-  integrity sha512-FtcwvrQ3HWlGRGChwlXiisMeKf9+XcCkMwVrrO0cxQavT01tIHx40OFtPOhXKGbgXGtRKcJI8XR41aK9t2kvyg==
+"@glimmer/manager@0.87.1", "@glimmer/manager@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/manager/-/manager-0.87.1.tgz#7936004b20e0ca6e336ba5553bfe129f5867295d"
+  integrity sha512-jEUZZQWcuxKg+Ri/A1HGURm9pBrx13JDHx1djYCnPo96yjtQFYxEG0VcwLq2EtAEpFrekwfO1b6m3JZiFqmtGg==
   dependencies:
-    "@glimmer/destroyable" "0.84.3"
+    "@glimmer/debug" "^0.87.1"
+    "@glimmer/destroyable" "^0.87.1"
     "@glimmer/env" "0.1.7"
-    "@glimmer/global-context" "0.84.3"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/reference" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/validator" "0.84.3"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/reference" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/validator" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
 
 "@glimmer/manager@>= 0.83.0", "@glimmer/manager@^0.92.0":
   version "0.92.0"
@@ -1391,29 +1401,31 @@
     "@glimmer/validator" "^0.92.0"
     "@glimmer/vm" "^0.92.0"
 
-"@glimmer/node@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.84.3.tgz#01679eaa33bcb8b3fc55f19cfb7ae078fb79503b"
-  integrity sha512-QXlZjr7X6DDTJ3wiYQIHv2Pq/5sdGeTTW15+U+IosjZuQgvwCPJaeXC2CU8yqgA33yHgMgJpkdvLnPUCPrrhwg==
+"@glimmer/node@0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.87.1.tgz#b82d9711ba59c9f571c01e84cd1d09ccdc6a8aaf"
+  integrity sha512-peESyArA08Va9f3gpBnhO+RNkK4Oe0Q8sMPQILCloAukNe2+DQOhTvDgVjRUKmVXMJCWoSgmJtxkiB3ZE193vw==
   dependencies:
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/runtime" "0.84.3"
-    "@glimmer/util" "0.84.3"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/runtime" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
     "@simple-dom/document" "^1.4.0"
-    "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/opcode-compiler@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.84.3.tgz#aa95000034d10786cb8fdbd199d66fb5498e90f3"
-  integrity sha512-flUuikKLFL9cekJUA10gJxMRCDjUPb61R3UCl1u69TGN0Nm7FTsMhOsVDtJLeeiAROtPx+NvasPw/6UB1rrdyg==
+"@glimmer/opcode-compiler@0.87.1", "@glimmer/opcode-compiler@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.87.1.tgz#89a5f2cbfc6e80b0762e7910ec05f74e0cccaf1d"
+  integrity sha512-D9OFrH3CrGNXfGtgcVWvu3xofpQZPoYFkqj3RrcDwnsSIYPSqUYTIOO6dwpxTbPlzkASidq0B2htXK7WkCERVw==
   dependencies:
-    "@glimmer/encoder" "0.84.3"
+    "@glimmer/debug" "^0.87.1"
+    "@glimmer/encoder" "^0.87.1"
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/reference" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/vm" "0.84.3"
-    "@glimmer/wire-format" "0.84.3"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/manager" "^0.87.1"
+    "@glimmer/reference" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
+    "@glimmer/wire-format" "^0.87.1"
 
 "@glimmer/opcode-compiler@^0.92.0":
   version "0.92.0"
@@ -1431,12 +1443,12 @@
     "@glimmer/vm" "^0.92.0"
     "@glimmer/wire-format" "^0.92.0"
 
-"@glimmer/owner@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/owner/-/owner-0.84.3.tgz#e64083b692452031bdf30cba4124d1fc64e6e5e2"
-  integrity sha512-ZwA0rU4V8m0z4ncXtWD2QEU6eh61wkKKQUThahPYhfB+JYceVM6Grx7uWeiAxc2v3ncpvbYqIGdnICXDMloxAA==
+"@glimmer/owner@0.87.1", "@glimmer/owner@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/owner/-/owner-0.87.1.tgz#0133096e754e7d644a59da84f019bdc21134e1e7"
+  integrity sha512-ayYjznPMSGpgygNT7XlTXeel6Cl/fafm4WJeRRgdPxG1EZMjKPlfpfAyNzf9peEIlW3WMbPu3RAIYrf54aThWQ==
   dependencies:
-    "@glimmer/util" "0.84.3"
+    "@glimmer/util" "^0.87.1"
 
 "@glimmer/owner@^0.92.0":
   version "0.92.0"
@@ -1445,17 +1457,19 @@
   dependencies:
     "@glimmer/util" "^0.92.0"
 
-"@glimmer/program@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.84.3.tgz#a93d5e2ecd1cb7b9e4582cc4d41d0f92b16f9cf5"
-  integrity sha512-D8z1lP8NEMyzT8gByFsZpmbRThZvGLS0Tl5AngaDbI2FqlcpEV0ujvLTzzgecd9QQ1k3Cd60dTgy/2N2CI82SA==
+"@glimmer/program@0.87.1", "@glimmer/program@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.87.1.tgz#b3132cd9369841c36578b06b802aae1c81ba3f22"
+  integrity sha512-+r1Dz5Da0zyYwBhPmqoXiw3qmDamqqhVmSCtJLLcZ6exXXC2ZjGoNdynfos80A91dx+PFqYgHg+5lfa5STT9iQ==
   dependencies:
-    "@glimmer/encoder" "0.84.3"
+    "@glimmer/encoder" "^0.87.1"
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/manager" "0.84.3"
-    "@glimmer/opcode-compiler" "0.84.3"
-    "@glimmer/util" "0.84.3"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/manager" "^0.87.1"
+    "@glimmer/opcode-compiler" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
+    "@glimmer/wire-format" "^0.87.1"
 
 "@glimmer/program@^0.92.0":
   version "0.92.0"
@@ -1471,16 +1485,16 @@
     "@glimmer/vm" "^0.92.0"
     "@glimmer/wire-format" "^0.92.0"
 
-"@glimmer/reference@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.84.3.tgz#6420ad9c102633ac83939fd1b2457269d21fb632"
-  integrity sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==
+"@glimmer/reference@0.87.1", "@glimmer/reference@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.87.1.tgz#f4c0bc906d867c2354f285cef5929129d05dd398"
+  integrity sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.84.3"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/validator" "0.84.3"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/validator" "^0.87.1"
 
 "@glimmer/reference@^0.92.0":
   version "0.92.0"
@@ -1493,24 +1507,23 @@
     "@glimmer/util" "^0.92.0"
     "@glimmer/validator" "^0.92.0"
 
-"@glimmer/runtime@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.84.3.tgz#d84c02b21ac127fe3da85c7722371406beb6763a"
-  integrity sha512-LzlJbPDCUH/wjsgJ5kRImvOkqAImSyVRW37t34n/1Qd3v7ZoI8xVQg92lS+2kHZe030sT49ZwKkEIeVZiBreBw==
+"@glimmer/runtime@0.87.1", "@glimmer/runtime@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.87.1.tgz#efb56b14f2a34d169ea29af39c857dfe79c10a7a"
+  integrity sha512-7QBONxRFesnHzelCiUahZjRj3nhbUxPg0F+iD+3rALrXaWfB1pkhngMTK2DYEmsJ7kq04qVzwBnTSrqsmLzOTg==
   dependencies:
-    "@glimmer/destroyable" "0.84.3"
+    "@glimmer/destroyable" "^0.87.1"
     "@glimmer/env" "0.1.7"
-    "@glimmer/global-context" "0.84.3"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/low-level" "0.78.2"
-    "@glimmer/owner" "0.84.3"
-    "@glimmer/program" "0.84.3"
-    "@glimmer/reference" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/validator" "0.84.3"
-    "@glimmer/vm" "0.84.3"
-    "@glimmer/wire-format" "0.84.3"
-    "@simple-dom/interface" "^1.4.0"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/manager" "^0.87.1"
+    "@glimmer/owner" "^0.87.1"
+    "@glimmer/program" "^0.87.1"
+    "@glimmer/reference" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/validator" "^0.87.1"
+    "@glimmer/vm" "^0.87.1"
+    "@glimmer/wire-format" "^0.87.1"
 
 "@glimmer/runtime@>= 0.83.0":
   version "0.92.0"
@@ -1530,7 +1543,18 @@
     "@glimmer/vm" "^0.92.0"
     "@glimmer/wire-format" "^0.92.0"
 
-"@glimmer/syntax@0.84.3", "@glimmer/syntax@^0.84.3":
+"@glimmer/syntax@0.87.1", "@glimmer/syntax@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.87.1.tgz#4f8372d7b5e57f109e897cd149097fcd51fe51a1"
+  integrity sha512-zYzZT6LgpSF0iv5iuxmMV5Pf52aE8dukNC2KfrHC6gXJfM4eLZMZcyk76NW5m+SEetZSOXX6AWv/KwLnoxiMfQ==
+  dependencies:
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
+    "@glimmer/wire-format" "^0.87.1"
+    "@handlebars/parser" "~2.0.0"
+    simple-html-tokenizer "^0.5.11"
+
+"@glimmer/syntax@^0.84.3":
   version "0.84.3"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.84.3.tgz#4045a1708cef7fd810cff42fe6deeba40c7286d0"
   integrity sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==
@@ -1560,6 +1584,14 @@
     "@glimmer/interfaces" "0.84.3"
     "@simple-dom/interface" "^1.4.0"
 
+"@glimmer/util@0.87.1", "@glimmer/util@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.87.1.tgz#f0e3f9cc7e57eb100e4a6b1d81a97850539d4f00"
+  integrity sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "^0.87.1"
+
 "@glimmer/util@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
@@ -1581,13 +1613,15 @@
     "@glimmer/env" "0.1.7"
     "@glimmer/interfaces" "^0.92.0"
 
-"@glimmer/validator@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.84.3.tgz#cd83b7f9ab78953f23cc11a32d83d7f729c54df2"
-  integrity sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==
+"@glimmer/validator@0.87.1", "@glimmer/validator@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.87.1.tgz#019d66afeff62adc70a9e698a8fd58544656fd82"
+  integrity sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.84.3"
+    "@glimmer/global-context" "^0.87.1"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
 
 "@glimmer/validator@^0.92.0":
   version "0.92.0"
@@ -1599,20 +1633,20 @@
     "@glimmer/interfaces" "^0.92.0"
     "@glimmer/util" "^0.92.0"
 
-"@glimmer/vm-babel-plugins@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.84.3.tgz#82fc094a75ff20086a45b088825e4d97d49b779a"
-  integrity sha512-fucWuuN7Q9QFB0ODd+PCltcTkmH4fLqYyXGArrfLt/TYN8gLv0yo00mPwFOSY7MWti/MUx88xd20/PycvYtg8w==
+"@glimmer/vm-babel-plugins@0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.87.1.tgz#a651e09e842b88290343764e34623b30b65582b5"
+  integrity sha512-VbhYHa+HfGFiTIOOkvFuYPwBTaDvWTAR1Q55RI25JI6Nno0duBLB3UVRTDgHM+iOfbgRN7OSR5XCe/C5X5C5LA==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
-"@glimmer/vm@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.84.3.tgz#45724ba7b4f90383de78a59071222bdc391ada98"
-  integrity sha512-3mBWvQLEbB8We2EwdmuALMT3zQEcE13ItfLJ0wxlSO2uj1uegeHat++mli8RMxeYNqex27DC+VuhHeWVve6Ngg==
+"@glimmer/vm@0.87.1", "@glimmer/vm@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.87.1.tgz#c8b37066927c4b49c5e49c014ab838d4875a33c7"
+  integrity sha512-JSFr85ASZmuN4H72px7GHtnW79PPRHpqHw6O/6UUZd+ocwWHy+nG9JGbo8kntvqN5xP0SdCipjv/c0u7nkc8tg==
   dependencies:
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/util" "0.84.3"
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
 
 "@glimmer/vm@^0.92.0":
   version "0.92.0"
@@ -1622,14 +1656,6 @@
     "@glimmer/interfaces" "^0.92.0"
     "@glimmer/util" "^0.92.0"
 
-"@glimmer/wire-format@0.84.3":
-  version "0.84.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.84.3.tgz#d31ac85e5f51e67636efe9c5fbd8ae3d5097d8b5"
-  integrity sha512-aZVfQhqv4k7tTo2vwjy+b4mAxKt7cHH75JR3zAeCilimApa+yYTYUyY73NDNSUVbelgAlQ5s6vTiMSQ55WwVow==
-  dependencies:
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/util" "0.84.3"
-
 "@glimmer/wire-format@^0.85.13":
   version "0.85.13"
   resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.85.13.tgz#a8df8c44646b8f0d09dda187ac64f45c33904b63"
@@ -1637,6 +1663,14 @@
   dependencies:
     "@glimmer/interfaces" "^0.85.13"
     "@glimmer/util" "^0.85.13"
+
+"@glimmer/wire-format@^0.87.1":
+  version "0.87.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.87.1.tgz#f0e31590dff9de7286d816911bf9c81f755949f5"
+  integrity sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==
+  dependencies:
+    "@glimmer/interfaces" "^0.87.1"
+    "@glimmer/util" "^0.87.1"
 
 "@glimmer/wire-format@^0.92.0":
   version "0.92.0"
@@ -2844,6 +2878,14 @@ babel-plugin-ember-template-compilation@^2.0.0, babel-plugin-ember-template-comp
     "@glimmer/syntax" "^0.84.3"
     babel-import-util "^2.0.0"
 
+babel-plugin-ember-template-compilation@^2.1.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.2.tgz#e3fdff0458730675716e320d2c4e0aa8fe8c4b25"
+  integrity sha512-wdT2F9/n6uC1rLvAjXCx5+fXbwkl8MIcwt0rg5csWedPbERdzQqhRlDqj0kIwNfUJ9gaXAcKrgSOUXbJcByGOQ==
+  dependencies:
+    "@glimmer/syntax" "^0.84.3"
+    babel-import-util "^2.0.0"
+
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-4.0.0.tgz#068f8da15236a96a9602c36dc6f4a6eeca70a4f4"
@@ -2921,10 +2963,10 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.7.0.tgz#36a5b8a8bfceb7efc8ad56e006a238924acfd67e"
-  integrity sha512-eBZC6r7wT+YYAOKeru8IqgzOimz3VgyspXiZ1k6MI8i10zUdU8cnNII56rlnItQ89cHgQO3C/nPuFW3V9di+zg==
+backburner.js@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.8.0.tgz#72f8c7455ff664ff8e79a32415977e10a18e03c7"
+  integrity sha512-zYXY0KvpD7/CWeOLF576mV8S+bQsaIoj/GNLXXB+Eb8SJcQy5lqSjkRrZ0MZhdKUs9QoqmGNIEIe3NQfGiiscQ==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -4733,35 +4775,36 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-5.4.0.tgz#c18df972074aad8b891c289f4657af63844a242c"
-  integrity sha512-y2fPd7DJ8D9IBjHSf6CPwU8TqNpqytpMgFyzf+9tPvu/u2Wdd45jEd2W1weKE3URQwPTcA0vK8Q1w6uzLOx/EA==
+ember-source@~5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-5.8.0.tgz#792f391b6b12f280dab6e6e89b923ef6d52f43ff"
+  integrity sha512-jRmT5egy7XG2G9pKNdNNwNBZqFxrl7xJwdYrJ3ugreR7zK1FR28lHSR5CMSKtYLmJZxu340cf2EbRohWEtO2Zw==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
-    "@babel/plugin-transform-block-scoping" "^7.22.5"
     "@ember/edition-utils" "^1.2.0"
-    "@glimmer/compiler" "0.84.3"
+    "@glimmer/compiler" "0.87.1"
     "@glimmer/component" "^1.1.2"
-    "@glimmer/destroyable" "0.84.3"
+    "@glimmer/destroyable" "0.87.1"
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.84.3"
-    "@glimmer/interfaces" "0.84.3"
-    "@glimmer/manager" "0.84.3"
-    "@glimmer/node" "0.84.3"
-    "@glimmer/opcode-compiler" "0.84.3"
-    "@glimmer/owner" "0.84.3"
-    "@glimmer/program" "0.84.3"
-    "@glimmer/reference" "0.84.3"
-    "@glimmer/runtime" "0.84.3"
-    "@glimmer/syntax" "0.84.3"
-    "@glimmer/util" "0.84.3"
-    "@glimmer/validator" "0.84.3"
-    "@glimmer/vm-babel-plugins" "0.84.3"
+    "@glimmer/global-context" "0.87.1"
+    "@glimmer/interfaces" "0.87.1"
+    "@glimmer/manager" "0.87.1"
+    "@glimmer/node" "0.87.1"
+    "@glimmer/opcode-compiler" "0.87.1"
+    "@glimmer/owner" "0.87.1"
+    "@glimmer/program" "0.87.1"
+    "@glimmer/reference" "0.87.1"
+    "@glimmer/runtime" "0.87.1"
+    "@glimmer/syntax" "0.87.1"
+    "@glimmer/util" "0.87.1"
+    "@glimmer/validator" "0.87.1"
+    "@glimmer/vm" "0.87.1"
+    "@glimmer/vm-babel-plugins" "0.87.1"
     "@simple-dom/interface" "^1.4.0"
     babel-plugin-debug-macros "^0.3.4"
+    babel-plugin-ember-template-compilation "^2.1.1"
     babel-plugin-filter-imports "^4.0.0"
-    backburner.js "^2.7.0"
+    backburner.js "^2.8.0"
     broccoli-concat "^4.2.5"
     broccoli-debug "^0.6.4"
     broccoli-file-creator "^2.1.1"
@@ -4779,11 +4822,11 @@ ember-source@~5.4.0:
     ember-cli-version-checker "^5.1.2"
     ember-router-generator "^2.0.0"
     inflection "^2.0.1"
-    resolve "^1.22.2"
     route-recognizer "^0.3.4"
     router_js "^8.0.3"
     semver "^7.5.2"
     silent-error "^1.1.1"
+    simple-html-tokenizer "^0.5.11"
 
 ember-try-config@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Build

#### Update `ember-cli` to v5.4.2

This update should address the security warning CVE-2021-23337:
- https://github.com/DazzlingFugu/ember-cli-embedded/security/dependabot/63
- https://github.com/ember-cli/ember-cli/pull/10458

#### Update `ember-source` to v5.8.0

Because why not, while we are at it.
