### PR TITLE
Release v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-embedded",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Control how your Ember application boots in non-Ember pages/apps.",
   "keywords": [
     "ember",


### PR DESCRIPTION
Changelog since our last version: https://github.com/DazzlingFugu/ember-cli-embedded/compare/v4.0.1...master

---

## Build

- Update `ember-cli` to v5.4.2 (#363)
- Update `ember-source` to v5.8.0 (#363)
- Run `yarn` to fix lockfile (#396)

## Dependencies

- Bump `@typescript-eslint/parser` from 6.9.1 to 6.14.0 (#312)
- Bump `@babel/core` from 7.23.2 to 7.23.3 (#313)
- Bump `@types/ember__owner` from 4.0.7 to 4.0.8 (#314)
- Bump `@types/qunit` from 2.19.7 to 2.19.9 (#315)
- Bump `@types/ember__service` from 4.0.6 to 4.0.8 (#316)
- Bump `@types/ember__debug` from 4.0.6 to 4.0.7 (#317)
- Bump `@types/ember__engine` from 4.0.8 to 4.0.10 (#318)
- Bump `@ember/test-helpers` from 3.2.0 to 3.2.1 (#319)
- Bump `qunit-dom` from 2.0.0 to 3.0.0 (#320)
- Bump `@types/ember__component` from 4.0.19 to 4.0.21 (#322)
- Bump `@types/ember__application` from 4.0.9 to 4.0.10 (#323)
- Bump `@embroider/test-setup` from 3.0.2 to 3.0.3 (#324)
- Bump `@typescript-eslint/parser` from 6.14.0 to 6.16.0 (#325)
- Bump `@typescript-eslint/eslint-plugin` from 6.9.1 to 6.16.0 (#326)
- Bump `eslint-plugin-prettier` from 5.0.1 to 5.1.2 (#327)
- Bump `@types/ember__controller` from 4.0.9 to 4.0.11 (#328)
- Bump `follow-redirects` from 1.15.3 to 1.15.4 (#329)
- Bump `@types/ember` from 4.0.8 to 4.0.10 (#330)
- Bump `@types/ember__polyfills` from 4.0.4 to 4.0.5 (#331)
- Bump `@types/ember__component` from 4.0.21 to 4.0.22 (#332)
- Bump `@glint/template` from 1.2.1 to 1.3.0 (#333)
- Bump `@types/ember__application` from 4.0.10 to 4.0.11 (#334)
- Bump `@types/ember__utils` from 4.0.5 to 4.0.7 (#335)
- Bump `@types/ember__engine` from 4.0.10 to 4.0.11 (#336)
- Bump `eslint-plugin-ember` from 11.11.1 to 12.0.0 (#337)
- Bump `@types/ember__service` from 4.0.8 to 4.0.9 (#339)
- Bump `eslint-plugin-n` from 16.2.0 to 16.6.2 (#340)
- Bump `@types/ember__template` from 4.0.4 to 4.0.7 (#341)
- Bump `@glint/environment-ember-loose` from 1.2.1 to 1.3.0 (#342)
- Bump `@types/ember__error` from 4.0.4 to 4.0.6 (#343)
- Bump `@types/ember__test` from 4.0.4 to 4.0.6 (#344)
- Bump `eslint-config-prettier` from 9.0.0 to 9.1.0 (#345)
- Bump `@types/ember__array` from 4.0.7 to 4.0.10 (#346)
- Bump `eslint` from 8.52.0 to 8.57.0 (#347)
- Bump `@ember/test-helpers` from 3.2.1 to 3.3.0 (#348)
- Bump `follow-redirects` from 1.15.4 to 1.15.6 (#349)
- Bump `@babel/core` from 7.23.3 to 7.24.3 (#350)
- Bump `@types/ember__owner` from 4.0.8 to 4.0.9 (#351)
- Bump `express` from 4.18.2 to 4.19.2 (#352)
- Bump `@types/ember__object` from 4.0.9 to 4.0.12 (#353)
- Bump `webpack` from 5.89.0 to 5.91.0 (#354)
- Bump `@glint/template` from 1.3.0 to 1.4.0 (#355)
- Bump `qunit` from 2.20.0 to 2.20.1 (#356)
- Bump `@types/qunit` from 2.19.9 to 2.19.10 (#356)
- Bump `@types/ember__routing` from 4.0.17 to 4.0.22 (#357)
- Bump `@tsconfig/ember` from 3.0.2 to 3.0.6 (#358)
- Bump `ember-auto-import` from 2.6.3 to 2.7.2 (#359)
- Bump `@types/ember` from 4.0.10 to 4.0.11 (#360)
- Bump `@types/ember__controller` from 4.0.11 to 4.0.12 (#361)
- Bump `@types/ember__helper` from 4.0.4 to 4.0.7 (#362)
- Bump `@types/ember__debug` from 4.0.7 to 4.0.8 (#364)
- Bump `eslint-plugin-n` from 16.6.2 to 17.4.0 (#365)
- Bump `eslint-plugin-prettier` from 5.1.2 to 5.1.3 (#366)
- Bump `@typescript-eslint/parser` from 6.16.0 to 6.21.0 (#367)
- Bump `@types/ember__polyfills` from 4.0.5 to 4.0.6 (#368)
- Bump `@types/ember__destroyable` from 4.0.3 to 4.0.5 (#369)
- Bump `eslint-plugin-ember` from 12.0.0 to 12.1.1 (#370)
- Bump `eslint-plugin-qunit` from 8.0.1 to 8.1.1 (#371)
- Bump `@glint/environment-ember-loose` from 1.3.0 to 1.4.0 (#372)
- Bump `@embroider/test-setup` from 3.0.3 to 4.0.0 (#373)
- Bump `typescript` from 5.2.2 to 5.4.5 (#374)
- Bump `ember-auto-import` from 2.7.2 to 2.7.3 (#375)
- Bump `rimraf` from 5.0.5 to 5.0.7 (#376)
- Bump `eslint-plugin-n` from 17.4.0 to 17.9.0 (#377)
- Bump `@types/ember__modifier` from 4.0.7 to 4.0.9 (#378)
- Bump `qunit` from 2.20.1 to 2.21.0 (#379)
- Bump `ember-auto-import` from 2.7.3 to 2.7.4 (#380)
- Bump `@ember/optional-features` from 2.0.0 to 2.1.0 (#381)
- Bump `ember-qunit` from 8.0.2 to 8.1.0 (#382)
- Bump `@types/rsvp` from 4.0.6 to 4.0.9 (#383)
- Bump `@tsconfig/ember` from 3.0.6 to 3.0.8 (#384)
- Bump `@types/ember__runloop` from 4.0.7 to 4.0.10 (#385)
- Bump `eslint-plugin-prettier` from 5.1.3 to 5.2.1 (#386)
- Bump `webpack` from 5.91.0 to 5.93.0 (#387)
- Bump `typescript` from 5.4.5 to 5.5.4 (#388)
- Bump `@types/ember__helper` from 4.0.7 to 4.0.8 (#390)
- Bump `@babel/core` from 7.24.3 to 7.25.2 (#391)
- Bump `@ember/test-helpers` from 3.3.0 to 3.3.1 (#392)
- Bump `@ember/string` from 3.1.1 to 4.0.0 (#394)
- Bump `prettier` from 3.0.3 to 3.3.3 (#395)
- Bump `@ember/test-helpers` from 3.3.1 to 4.0.2 (#397)
- Bump `@typescript-eslint/eslint-plugin (#398)
- Bump `qunit-dom` from 3.0.0 to 3.2.0 (#399)
- Bump `eslint-plugin-ember` from 12.1.1 to 12.2.0 (#400)
- Bump `webpack` from 5.93.0 to 5.94.0 (#401)
- Bump `eslint-plugin-n` from 17.9.0 to 17.10.2 (#402)
- Bump `qunit` from 2.21.0 to 2.22.0 (#403)
- Bump `@ember/test-helpers` from 4.0.2 to 4.0.4 (#404)
- Bump `ember-source` from 5.8.0 to 5.11.0 (#405)
- Bump `express` from 4.19.2 to 4.21.0 (#406)
- Bump `ember-resolver` from 11.0.1 to 13.0.1 (#407)
- Bump `typescript` from 5.5.4 to 5.6.2 (#408)
- Bump `webpack` from 5.94.0 to 5.95.0 (#409)
- Bump `ember-auto-import` from 2.7.4 to 2.8.1 (#410)
- Bump `eslint-plugin-ember` from 12.2.0 to 12.2.1 (#411)
- Bump `concurrently` from 8.2.2 to 9.0.1 (#412)
- Bump `@babel/core` from 7.25.2 to 7.25.8 (#413)
- Bump `ember-resolver` from 13.0.1 to 13.0.2 (#414)
