### PR TITLE
Revert "build(deps-dev): bump eslint-config-prettier from 9.1.0 to 10.0.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^3.0.0",
     "eslint": "^9.16.0",
-    "eslint-config-prettier": "^10.0.2",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^12.3.3",
     "eslint-plugin-n": "^17.14.0",
     "eslint-plugin-prettier": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4872,10 +4872,10 @@ eslint-compat-utils@^0.5.1:
   dependencies:
     semver "^7.5.4"
 
-eslint-config-prettier@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.0.2.tgz#47444de8aa104ce82c2f91ad2a5e96b62c01e20d"
-  integrity sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==
+eslint-config-prettier@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
 eslint-plugin-ember@^12.3.3:
   version "12.3.3"


### PR DESCRIPTION
## Revert

#### Reverts DazzlingFugu/ember-cli-embedded#460

Reason: `master` has started to fail

https://github.com/DazzlingFugu/ember-cli-embedded/actions/runs/13641137808/job/38131518200

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/f4adacef-e60f-4c6e-a275-913d9adcc3ec" />
